### PR TITLE
fix: bump Go toolchain to 1.26.4 (stdlib CVEs GO-2026-5039/5037/4971)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # builder image
 # https://hub.docker.com/_/golang/tags
-FROM golang:1.26.2@sha256:2a2b4b5791cea8ae09caecba7bad0bd9631def96e5fe362e4a5e67009fe4ae61 AS builder
+FROM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AndriyKalashnykov/golang-web
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
Freshly-disclosed Go **stdlib** CVEs reddened `main` (`make vulncheck`/govulncheck):

- **GO-2026-5039** — net/textproto arbitrary input in errors (fixed in go1.26.4)
- **GO-2026-5037** — crypto/x509 inefficient hostname parsing (fixed in go1.26.4)
- **GO-2026-4971** — net panic on NUL byte (fixed in go1.26.3)

Fix: bump the Go toolchain to **1.26.4** (smallest patched version covering all three).

- `go.mod`: `go 1.26.2` → `go 1.26.4`
- `Dockerfile`: builder `golang:1.26.2@sha256:2a2b…` → `golang:1.26.4@sha256:f96c…` (tag + index digest)
- CI resolves Go via `go-version-file: go.mod`, so it follows automatically.

Verified: `govulncheck ./...` under go1.26.4 shows the three stdlib findings gone; `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)